### PR TITLE
API: Python 3 compatibility

### DIFF
--- a/elasticsearch.py
+++ b/elasticsearch.py
@@ -97,12 +97,12 @@ class CallbackModule(CallbackBase):
         if self.db_import:
             try:
                 self.es = self.elasticsearch.Elasticsearch(self.es_address, timeout=self.timeout)
-            except Exception, e:
+            except Exception as e:
                 logging.error("Failed to connect elasticsearch server '%s'. Exception = %s " % (self.es_address, e))
                 return False
             try:
                 return self.es.ping()
-            except Exception, e:
+            except Exception as e:
                 logging.error("Failed to get ping from elasticsearch server '%s'. Exception = %s " % (self.es_address, e))
                 return False
 
@@ -115,7 +115,7 @@ class CallbackModule(CallbackBase):
                 result = self.helpers.helpers.bulk(self.es, self.run_output,index=self.index_name)
                 if result:
                     return True
-            except Exception, e:
+            except Exception as e:
                 logging.error("Inserting data into elasticsearch 'failed' because %s" % e)
         return False
 


### PR DESCRIPTION
This PR resolves the issue with the Python 3 exceptions syntax.

@enginyoyen, thanks for the nice example! Are you enthusiastic about proposing this callback to ansible's repo?